### PR TITLE
Generalize fetch function

### DIFF
--- a/src/conduit/api.cljs
+++ b/src/conduit/api.cljs
@@ -40,17 +40,19 @@
                   status/ok (p/resolved (parse-body body))
                   (p/rejected (parse-body body)))))))
 
-(defn fetch [{:keys [endpoint params slug method type headers]}]
+(defn fetch [{:keys [endpoint params slug method json authorized xhr-params]}]
   (let [xhr-fn (case method
                  :post xhr/post
                  :put xhr/put
                  :patch xhr/patch
-                 xhr/get)
-         xhr-params {:query-params (when-not (= method :post) params)
-                     :body (when (= method :post) (->json params))
-                     :headers (case type
-                                :json (merge headers {"Content-Type" "application/json"})
-                                headers)}]
+                 (if (not= nil json) xhr/post xhr/get))
+        xhr-params (-> xhr-params
+                       (update-in [:query-params] #(if (not= nil params) (merge % params) %))
+                       (update-in [:body] #(if (not= nil json) (->json json) %))
+                       (update-in [:headers "Content-Type"] #(if (not= nil json) "application/json" %))
+                       (update-in [:headers "Authorization"] #(if (= true authorized)
+                                                                (str "Token " (.getItem js/localStorage "jwt-token")) %))
+                       (update-in [:headers] (fn [h] (into {} (filter #(-> % val (not= nil)) h)))))]
      (-> (->endpoint endpoint slug)
          ->uri
          (->xhr xhr-fn xhr-params))))

--- a/src/conduit/api.cljs
+++ b/src/conduit/api.cljs
@@ -29,6 +29,9 @@
       js/JSON.parse
       (js->clj :keywordize-keys true)))
 
+(defn- ->json [params]
+  (.stringify js/JSON (clj->js params)))
+
 (defn- ->xhr [uri xhr-fn params]
   (-> uri
       (xhr-fn params)
@@ -37,22 +40,17 @@
                   status/ok (p/resolved (parse-body body))
                   (p/rejected (parse-body body)))))))
 
-(defn fetch
-  ([endpoint]
-   (fetch endpoint nil))
-  ([endpoint params]
-   (fetch endpoint params nil))
-  ([endpoint params slug]
-   (fetch endpoint params slug nil))
-  ([endpoint params slug method]
-   (fetch endpoint params slug method nil))
-  ([endpoint params slug method type]
-   (fetch endpoint params slug method type nil))
-  ([endpoint params slug method type headers]
-   (let [xhr-fn (if (= method :post) xhr/post xhr/get)
-         xhr-params {:query-params (when (not (= method :post)) params)
-                     :body (when (= method :post) (.stringify js/JSON (clj->js params)))
-                     :headers (if (= type :json) (merge headers {"Content-Type" "application/json"}) headers)}]
+(defn fetch [{:keys [endpoint params slug method type headers]}]
+  (let [xhr-fn (case method
+                 :post xhr/post
+                 :put xhr/put
+                 :patch xhr/patch
+                 xhr/get)
+         xhr-params {:query-params (when-not (= method :post) params)
+                     :body (when (= method :post) (->json params))
+                     :headers (case type
+                                :json (merge headers {"Content-Type" "application/json"})
+                                headers)}]
      (-> (->endpoint endpoint slug)
          ->uri
-         (->xhr xhr-fn xhr-params)))))
+         (->xhr xhr-fn xhr-params))))

--- a/src/conduit/api.cljs
+++ b/src/conduit/api.cljs
@@ -40,13 +40,13 @@
                   status/ok (p/resolved (parse-body body))
                   (p/rejected (parse-body body)))))))
 
-(defn fetch [{:keys [endpoint params slug method json authorized xhr-params]}]
+(defn fetch [{:keys [endpoint params slug method json authorized xhr-options]}]
   (let [xhr-fn (case method
                  :post xhr/post
                  :put xhr/put
                  :patch xhr/patch
                  (if (not= nil json) xhr/post xhr/get))
-        xhr-params (-> xhr-params
+        xhr-params (-> xhr-options
                        (update-in [:query-params] #(if (not= nil params) (merge % params) %))
                        (update-in [:body] #(if (not= nil json) (->json json) %))
                        (update-in [:headers "Content-Type"] #(if (not= nil json) "application/json" %))

--- a/src/conduit/api.cljs
+++ b/src/conduit/api.cljs
@@ -44,19 +44,15 @@
    (fetch endpoint params nil))
   ([endpoint params slug]
    (fetch endpoint params slug nil))
-  ([endpoint params slug headers]
-   (-> (->endpoint endpoint slug)
-       ->uri
-       (->xhr xhr/get {:query-params params
-                       :headers headers}))))
-
-(defn post
-  ([endpoint]
-   (fetch endpoint nil))
-  ([endpoint params]
-   (fetch endpoint params nil))
-  ([endpoint params slug]
-   (-> (->endpoint endpoint slug)
-       ->uri
-       (->xhr xhr/post {:body (.stringify js/JSON (clj->js params))
-                        :headers {"Content-Type" "application/json"}}))))
+  ([endpoint params slug method]
+   (fetch endpoint params slug method nil))
+  ([endpoint params slug method type]
+   (fetch endpoint params slug method type nil))
+  ([endpoint params slug method type headers]
+   (let [xhr-fn (if (= method :post) xhr/post xhr/get)
+         xhr-params {:query-params (when (not (= method :post)) params)
+                     :body (when (= method :post) (.stringify js/JSON (clj->js params)))
+                     :headers (if (= type :json) (merge headers {"Content-Type" "application/json"}) headers)}]
+     (-> (->endpoint endpoint slug)
+         ->uri
+         (->xhr xhr-fn xhr-params)))))

--- a/src/conduit/controllers/user.cljs
+++ b/src/conduit/controllers/user.cljs
@@ -18,6 +18,7 @@
    :http {:endpoint :login
           :params {:user {:email email :password password}}
           :method :post
+          :type :json
           :on-load :login-success
           :on-error :form-submit-error}})
 

--- a/src/conduit/effects.cljs
+++ b/src/conduit/effects.cljs
@@ -3,13 +3,14 @@
             [conduit.api :as api]
             [promesa.core :as p]))
 
-(defn http [r c {:keys [endpoint params slug on-load on-error method type headers]}]
+(defn http [r c {:keys [endpoint params slug on-load on-error method json authorized xhr-params]}]
   (-> (api/fetch {:endpoint endpoint
                   :params params
                   :slug slug
                   :method method
-                  :type type
-                  :headers headers})
+                  :json json
+                  :authorized authorized
+                  :xhr-params xhr-params})
       (p/then #(citrus/dispatch! r c on-load %))
       (p/catch #(citrus/dispatch! r c on-error %))))
 

--- a/src/conduit/effects.cljs
+++ b/src/conduit/effects.cljs
@@ -3,15 +3,8 @@
             [conduit.api :as api]
             [promesa.core :as p]))
 
-(defmulti http (fn [_ _ params] (:method params)))
-
-(defmethod http :post [r c {:keys [endpoint params slug on-load on-error]}]
-  (-> (api/post endpoint params slug)
-      (p/then #(citrus/dispatch! r c on-load %))
-      (p/catch #(citrus/dispatch! r c on-error %))))
-
-(defmethod http :default [r c {:keys [endpoint params slug on-load on-error headers]}]
-  (-> (api/fetch endpoint params slug headers)
+(defn http [r c {:keys [endpoint params slug on-load on-error method type headers]}]
+  (-> (api/fetch endpoint params slug method type headers)
       (p/then #(citrus/dispatch! r c on-load %))
       (p/catch #(citrus/dispatch! r c on-error %))))
 

--- a/src/conduit/effects.cljs
+++ b/src/conduit/effects.cljs
@@ -3,14 +3,14 @@
             [conduit.api :as api]
             [promesa.core :as p]))
 
-(defn http [r c {:keys [endpoint params slug on-load on-error method json authorized xhr-params]}]
+(defn http [r c {:keys [endpoint params slug on-load on-error method json authorized xhr-options]}]
   (-> (api/fetch {:endpoint endpoint
                   :params params
                   :slug slug
                   :method method
                   :json json
                   :authorized authorized
-                  :xhr-params xhr-params})
+                  :xhr-options xhr-options})
       (p/then #(citrus/dispatch! r c on-load %))
       (p/catch #(citrus/dispatch! r c on-error %))))
 

--- a/src/conduit/effects.cljs
+++ b/src/conduit/effects.cljs
@@ -4,7 +4,12 @@
             [promesa.core :as p]))
 
 (defn http [r c {:keys [endpoint params slug on-load on-error method type headers]}]
-  (-> (api/fetch endpoint params slug method type headers)
+  (-> (api/fetch {:endpoint endpoint
+                  :params params
+                  :slug slug
+                  :method method
+                  :type type
+                  :headers headers})
       (p/then #(citrus/dispatch! r c on-load %))
       (p/catch #(citrus/dispatch! r c on-error %))))
 

--- a/src/conduit/effects.cljs
+++ b/src/conduit/effects.cljs
@@ -3,14 +3,13 @@
             [conduit.api :as api]
             [promesa.core :as p]))
 
-(defn http [r c {:keys [endpoint params slug on-load on-error method json authorized xhr-options]}]
+(defn http [r c {:keys [endpoint params slug on-load on-error method type headers]}]
   (-> (api/fetch {:endpoint endpoint
                   :params params
                   :slug slug
                   :method method
-                  :json json
-                  :authorized authorized
-                  :xhr-options xhr-options})
+                  :type type
+                  :headers headers})
       (p/then #(citrus/dispatch! r c on-load %))
       (p/catch #(citrus/dispatch! r c on-error %))))
 


### PR DESCRIPTION
- cover both `get` and `post` requests by supplying `:method` option with one of the possible request methods
- set `Content-Type` header automatically by providing `:type :json`