### PR TITLE
dispatch-on-mount mixin refactoring

### DIFF
--- a/src/conduit/components/article.cljs
+++ b/src/conduit/components/article.cljs
@@ -63,8 +63,9 @@
 (rum/defc Article <
   rum/reactive
   (mixins/dispatch-on-mount
-    {:article :load
-     :comments :load})
+   (fn []
+    {:article [:load]
+     :comments [:load]}))
   [r route params]
   (let [article (rum/react (citrus/subscription r [:article]))
         comments (rum/react (citrus/subscription r [:comments]))]

--- a/src/conduit/components/home.cljs
+++ b/src/conduit/components/home.cljs
@@ -129,9 +129,10 @@
 (rum/defc Home <
   rum/reactive
   (mixins/dispatch-on-mount
-    {:tag-articles :reset
-     :articles :load
-     :tags :load})
+   (fn []
+    {:tag-articles [:reset]
+     :articles [:load]
+     :tags [:load]}))
   [r route params]
   (let [articles (rum/react (citrus/subscription r [:articles]))
         tags (rum/react (citrus/subscription r [:tags]))]
@@ -140,8 +141,9 @@
 (rum/defc HomeTag <
   rum/reactive
   (mixins/dispatch-on-mount
-    {:tag-articles :load
-     :tags :load})
+   (fn [_ _ {:keys [id]}]
+    {:tag-articles [:load {:tag id}]
+     :tags [:load]}))
   [r route {:keys [id]}]
   (let [tag-articles (rum/react (citrus/subscription r [:tag-articles]))
         tags (rum/react (citrus/subscription r [:tags]))]

--- a/src/conduit/controllers/tag_articles.cljs
+++ b/src/conduit/controllers/tag_articles.cljs
@@ -14,10 +14,10 @@
 (defmethod control :init []
   {:state initial-state})
 
-(defmethod control :load [_ [{:keys [id]}] state]
+(defmethod control :load [_ [{:keys [tag]}] state]
   {:state (assoc state :loading? true)
    :http {:endpoint :articles
-          :params {:tag id}
+          :params {:tag tag}
           :on-load :load-ready}})
 
 (defmethod control :load-ready [_ [{:keys [articles articlesCount]}] state]

--- a/src/conduit/mixins.cljs
+++ b/src/conduit/mixins.cljs
@@ -2,18 +2,15 @@
   (:require [rum.core :as rum]
             [citrus.core :as citrus]))
 
-(defn dispatch-on-mount [events]
+(defn dispatch-on-mount [events-fn]
   {:did-mount
-   (fn [{[r _ params] :rum/args
-         :as state}]
-     (doseq [[ctrl event] events]
-       (citrus/dispatch! r ctrl event params))
+   (fn [{[r] :rum/args :as state}]
+     (doseq [[ctrl event-vector] (apply events-fn (:rum/args state))]
+       (apply citrus/dispatch! (into [r ctrl] event-vector)))
      state)
    :did-remount
-   (fn [old
-        {[r _ params] :rum/args
-         :as state}]
+   (fn [old {[r] :rum/args :as state}]
      (when (not= (:rum/args old) (:rum/args state))
-       (doseq [[ctrl event] events]
-         (citrus/dispatch! r ctrl event params)))
+       (doseq [[ctrl event-vector] (apply events-fn (:rum/args state))]
+         (apply citrus/dispatch! (into [r ctrl] event-vector))))
      state)})


### PR DESCRIPTION
Current PR provides the ability to set mixin dispatch params explicitly, based on component props if needed.