### PR TITLE
add dispatch effect

### DIFF
--- a/src/conduit/core.cljs
+++ b/src/conduit/core.cljs
@@ -36,7 +36,8 @@
       :user user/control}
      :effect-handlers {:http effects/http
                        :local-storage effects/local-storage
-                       :redirect effects/redirect}}))
+                       :redirect effects/redirect
+                       :dispatch effects/dispatch}}))
 
 ;; initialize controllers
 (defonce init-ctrl (citrus/broadcast-sync! reconciler :init))

--- a/src/conduit/effects.cljs
+++ b/src/conduit/effects.cljs
@@ -25,3 +25,7 @@
 
 (defn redirect [_ _ path]
   (set! (.-hash js/location) (str "#/" path)))
+
+(defn dispatch [r _ events]
+  (doseq [[ctrl event-vector] events]
+    (apply citrus/dispatch! (into [r ctrl] event-vector))))


### PR DESCRIPTION
Provides the ability to build chains of actions in the terms of effects data structures. The usage syntax is pretty the same as dispatch-on-mount mixin has:
`{:dispatch {:controller-name [:action-name "arg1" "arg2"]}}`

Example of usage:
```
;; assume this controller is passed to the reconciler under the :foo key

(defmulti control (fn [event] event))

(defmethod control :some-event []
  (js/console.log "some event handled")
  {:dispatch {:foo [:some-another-event]}})

(defmethod control :some-another-event []
  (js/console.log "some another event handled"))
```